### PR TITLE
Thalo eventstoredb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/target
 *.env
 **/.DS_Store
+*.code-workspace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,9 +238,9 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "core-foundation"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6888e10551bb93e424d8df1d07f1a8b4fceb0001a3a4b048bfc47554946f47b3"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -385,13 +385,13 @@ dependencies = [
 
 [[package]]
 name = "eventstore"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad2dd74e7cd524c6639c53adeb37210a1939e2770bafc8b75f5c7f3e797e47fb"
+checksum = "78735281a65a51a59bd2f6d10038d00bdb21ce3a3c699bf7701b7ff7439b36c3"
 dependencies = [
  "async-stream",
- "async-trait",
  "base64",
+ "bitflags",
  "byteorder",
  "bytes",
  "futures",
@@ -411,6 +411,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "tonic-types",
+ "urlencoding",
  "uuid",
  "webpki 0.21.4",
 ]
@@ -1566,9 +1567,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fed7948b6c68acbb6e20c334f55ad635dc0f75506963de4464289fbd3b051ac"
+checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1579,9 +1580,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a57321bf8bc2362081b2599912d2961fe899c0efadf1b4b2f8d48b3e253bb96c"
+checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2225,6 +2226,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b90931029ab9b034b300b797048cf23723400aa757e8a2bfb9d748102f9821"
 
 [[package]]
 name = "uuid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,18 +146,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "bitvec"
-version = "0.19.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55f93d0ef3363c364d5976646a38f04cf67cfe1d4c8d160cdea02cab2c116b33"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
 name = "blake2b_simd"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,12 +363,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dc8abb250ffdda33912550faa54c88ec8b998dec0b2c55ab224921ce11df"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "esdl"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "350fa3483cae7d2a5793d2e8c4aefd06dc17ca1de3d9fdbbd577451a2a0dc0e0"
 dependencies = [
- "nom 7.1.0",
+ "nom",
  "nom-supreme",
  "serde",
  "thiserror",
@@ -388,10 +385,11 @@ dependencies = [
 
 [[package]]
 name = "eventstore"
-version = "1.0.0"
+version = "2.0.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28db0beb21c0c9e7625ec205e967fd5bde790de29a3e8d167f771e0c2e64173f"
+checksum = "ad2dd74e7cd524c6639c53adeb37210a1939e2770bafc8b75f5c7f3e797e47fb"
 dependencies = [
+ "async-stream",
  "async-trait",
  "base64",
  "byteorder",
@@ -399,20 +397,22 @@ dependencies = [
  "futures",
  "http",
  "log",
- "nom 6.1.2",
- "prost 0.7.0",
- "prost-derive 0.7.0",
- "prost-types 0.7.0",
+ "nom",
+ "prost",
+ "prost-derive",
+ "prost-types",
  "rand",
- "rustls",
+ "reqwest",
+ "rustls 0.19.1",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
- "tonic 0.4.3",
- "tonic-build 0.4.2",
+ "tonic",
+ "tonic-build",
+ "tonic-types",
  "uuid",
- "webpki",
+ "webpki 0.21.4",
 ]
 
 [[package]]
@@ -431,15 +431,15 @@ version = "0.1.0"
 dependencies = [
  "crossterm",
  "futures-util",
- "prost 0.9.0",
+ "prost",
  "serde_json",
  "text_io",
  "thalo",
  "thalo-inmemory",
  "tokio",
  "tokio-stream",
- "tonic 0.6.2",
- "tonic-build 0.6.2",
+ "tonic",
+ "tonic-build",
 ]
 
 [[package]]
@@ -459,12 +459,6 @@ dependencies = [
 
 [[package]]
 name = "fixedbitset"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
-
-[[package]]
-name = "fixedbitset"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
@@ -476,10 +470,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "funty"
-version = "1.1.0"
+name = "form_urlencoded"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
 
 [[package]]
 name = "futures"
@@ -719,6 +717,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
+dependencies = [
+ "http",
+ "hyper",
+ "rustls 0.20.2",
+ "tokio",
+ "tokio-rustls 0.23.2",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -728,6 +739,17 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -756,13 +778,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.9.0"
+name = "ipnet"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
-dependencies = [
- "either",
-]
+checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
 name = "itertools"
@@ -807,19 +826,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "lexical-core"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
-dependencies = [
- "arrayvec 0.5.2",
- "bitflags",
- "cfg-if",
- "ryu",
- "static_assertions",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -856,6 +862,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matches"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
+
+[[package]]
 name = "md-5"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -869,6 +881,12 @@ name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "minimal-lexical"
@@ -906,19 +924,6 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "nom"
-version = "6.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2"
-dependencies = [
- "bitvec",
- "funty",
- "lexical-core",
- "memchr",
- "version_check",
-]
-
-[[package]]
-name = "nom"
 version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b1d11e1ef389c76fe5b81bcaf2ea32cf88b62bc494e19f493d0b30e7a930109"
@@ -938,7 +943,7 @@ dependencies = [
  "indent_write",
  "joinery",
  "memchr",
- "nom 7.1.0",
+ "nom",
 ]
 
 [[package]]
@@ -1045,21 +1050,11 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "petgraph"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
-dependencies = [
- "fixedbitset 0.2.0",
- "indexmap",
-]
-
-[[package]]
-name = "petgraph"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
 dependencies = [
- "fixedbitset 0.4.1",
+ "fixedbitset",
  "indexmap",
 ]
 
@@ -1216,40 +1211,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
-dependencies = [
- "bytes",
- "prost-derive 0.7.0",
-]
-
-[[package]]
-name = "prost"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
 dependencies = [
  "bytes",
- "prost-derive 0.9.0",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
-dependencies = [
- "bytes",
- "heck 0.3.3",
- "itertools 0.9.0",
- "log",
- "multimap",
- "petgraph 0.5.1",
- "prost 0.7.0",
- "prost-types 0.7.0",
- "tempfile",
- "which",
+ "prost-derive",
 ]
 
 [[package]]
@@ -1260,29 +1227,16 @@ checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
 dependencies = [
  "bytes",
  "heck 0.3.3",
- "itertools 0.10.3",
+ "itertools",
  "lazy_static",
  "log",
  "multimap",
- "petgraph 0.6.0",
- "prost 0.9.0",
- "prost-types 0.9.0",
+ "petgraph",
+ "prost",
+ "prost-types",
  "regex",
  "tempfile",
  "which",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
-dependencies = [
- "anyhow",
- "itertools 0.9.0",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1292,20 +1246,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
 dependencies = [
  "anyhow",
- "itertools 0.10.3",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
-dependencies = [
- "bytes",
- "prost 0.7.0",
 ]
 
 [[package]]
@@ -1315,7 +1259,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
 dependencies = [
  "bytes",
- "prost 0.9.0",
+ "prost",
 ]
 
 [[package]]
@@ -1326,12 +1270,6 @@ checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "radium"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
 
 [[package]]
 name = "rand"
@@ -1461,6 +1399,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f242f1488a539a79bac6dbe7c8609ae43b7914b7736210f239a37cccb32525"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls 0.20.2",
+ "rustls-native-certs 0.6.1",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-rustls 0.23.2",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+ "winreg",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1496,8 +1473,20 @@ dependencies = [
  "base64",
  "log",
  "ring",
- "sct",
- "webpki",
+ "sct 0.6.1",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "rustls"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d37e5e2290f3e040b594b1a9e04377c2c671f1a1cfd9bfdef82106ac1c113f84"
+dependencies = [
+ "log",
+ "ring",
+ "sct 0.7.0",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -1507,9 +1496,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
 dependencies = [
  "openssl-probe",
- "rustls",
+ "rustls 0.19.1",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca9ebdfa27d3fc180e42879037b5338ab1c040c06affd00d8338598e7800943"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
+dependencies = [
+ "base64",
 ]
 
 [[package]]
@@ -1539,6 +1549,16 @@ name = "sct"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
@@ -1593,6 +1613,18 @@ version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c059c05b48c5c0067d4b4b2b4f0732dd65feb52daf7e0ea09cd87e7dadc1af79"
 dependencies = [
+ "itoa 1.0.1",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
  "itoa 1.0.1",
  "ryu",
  "serde",
@@ -1674,12 +1706,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "stringprep"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1705,12 +1731,6 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -1756,7 +1776,7 @@ dependencies = [
  "thalo-macros",
  "thiserror",
  "tokio-stream",
- "tonic 0.6.2",
+ "tonic",
 ]
 
 [[package]]
@@ -1771,6 +1791,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thalo",
+ "thiserror",
 ]
 
 [[package]]
@@ -1958,9 +1979,20 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
 dependencies = [
- "rustls",
+ "rustls 0.19.1",
  "tokio",
- "webpki",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a27d5f2b839802bd8267fa19b0530f5a08b9c08cd417976be2a65d130fe1c11b"
+dependencies = [
+ "rustls 0.20.2",
+ "tokio",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -2000,37 +2032,6 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ac42cd97ac6bd2339af5bcabf105540e21e45636ec6fa6aae5e85d44db31be0"
-dependencies = [
- "async-stream",
- "async-trait",
- "base64",
- "bytes",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
- "percent-encoding",
- "pin-project",
- "prost 0.7.0",
- "prost-derive 0.7.0",
- "rustls-native-certs",
- "tokio",
- "tokio-rustls",
- "tokio-stream",
- "tokio-util",
- "tower",
- "tower-service",
- "tracing",
- "tracing-futures",
-]
-
-[[package]]
-name = "tonic"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff08f4649d10a70ffa3522ca559031285d8e421d727ac85c60825761818f5d0a"
@@ -2048,9 +2049,11 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost 0.9.0",
- "prost-derive 0.9.0",
+ "prost",
+ "prost-derive",
+ "rustls-native-certs 0.5.0",
  "tokio",
+ "tokio-rustls 0.22.0",
  "tokio-stream",
  "tokio-util",
  "tower",
@@ -2062,26 +2065,25 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c695de27302f4697191dda1c7178131a8cb805463dda02864acb80fe1322fdcf"
-dependencies = [
- "proc-macro2",
- "prost-build 0.7.0",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "tonic-build"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9403f1bafde247186684b230dc6f38b5cd514584e8bec1dd32514be4745fa757"
 dependencies = [
  "proc-macro2",
- "prost-build 0.9.0",
+ "prost-build",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tonic-types"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40815ef5651cdebb73618ab877c159da73867f5dd5efbe7a1d27fb1cb3c3c95b"
+dependencies = [
+ "prost",
+ "prost-build",
+ "prost-types",
 ]
 
 [[package]]
@@ -2212,6 +2214,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
+name = "url"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
 name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2281,6 +2295,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb6ec270a31b1d3c7e266b999739109abce8b6c87e4b31fcfcd788b65267395"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2330,6 +2356,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552ceb903e957524388c4d3475725ff2c8b7960922063af6ce53c9a43da07449"
+dependencies = [
+ "webpki 0.22.0",
+]
+
+[[package]]
 name = "which"
 version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2363,7 +2408,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "wyz"
-version = "0.2.0"
+name = "winreg"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
+checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
+dependencies = [
+ "winapi",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,9 +385,9 @@ dependencies = [
 
 [[package]]
 name = "eventstore"
-version = "2.0.0-alpha.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78735281a65a51a59bd2f6d10038d00bdb21ce3a3c699bf7701b7ff7439b36c3"
+checksum = "6adac036ea9bd2f6860f24652fd6a2648fa889b4b764d1e929db727b8e28aa22"
 dependencies = [
  "async-stream",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -31,28 +40,43 @@ name = "async-stream"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e"
-dependencies = ["async-stream-impl", "futures-core"]
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+]
 
 [[package]]
 name = "async-stream-impl"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
-dependencies = ["proc-macro2", "quote", "syn"]
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "async-trait"
 version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
-dependencies = ["proc-macro2", "quote", "syn"]
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = ["hermit-abi", "libc", "winapi"]
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "autocfg"
@@ -66,27 +90,27 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00f1e8a972137fad81e2a1a60b86ff17ce0338f8017264e45a9723d0083c39a1"
 dependencies = [
-  "async-trait",
-  "axum-core",
-  "bitflags",
-  "bytes",
-  "futures-util",
-  "http",
-  "http-body",
-  "hyper",
-  "itoa 1.0.1",
-  "matchit",
-  "memchr",
-  "mime",
-  "percent-encoding",
-  "pin-project-lite",
-  "serde",
-  "sync_wrapper",
-  "tokio",
-  "tower",
-  "tower-http",
-  "tower-layer",
-  "tower-service",
+ "async-trait",
+ "axum-core",
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa 1.0.1",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -95,12 +119,12 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da31c0ed7b4690e2c78fe4b880d21cd7db04a346ebc658b4270251b695437f17"
 dependencies = [
-  "async-trait",
-  "bytes",
-  "futures-util",
-  "http",
-  "http-body",
-  "mime",
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
 ]
 
 [[package]]
@@ -115,11 +139,11 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1627eccf3aa91405435ba240be23513eeca466b5dc33866422672264de061582"
 dependencies = [
-  "async-trait",
-  "futures-channel",
-  "futures-util",
-  "parking_lot",
-  "tokio",
+ "async-trait",
+ "futures-channel",
+ "futures-util",
+ "parking_lot",
+ "tokio",
 ]
 
 [[package]]
@@ -127,21 +151,36 @@ name = "bb8-postgres"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0a22f6e28b0cf30a1861b69e3defedad0b98991a5bc54ab11bb0c2e20927686"
-dependencies = ["async-trait", "bb8", "tokio", "tokio-postgres"]
+dependencies = [
+ "async-trait",
+ "bb8",
+ "tokio",
+ "tokio-postgres",
+]
 
 [[package]]
 name = "better-bae"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c42256f0525b8d9cb8e6573ba850478df93ba34ddd7bf64eeb47ff19a8422bc5"
-dependencies = ["better-bae-macros", "proc-macro2", "syn"]
+dependencies = [
+ "better-bae-macros",
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "better-bae-macros"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b0f3144c211af9910842422e6835938ff01895bca8c143e28dcebdd23eb2dbc"
-dependencies = ["heck", "proc-macro-error", "proc-macro2", "quote", "syn"]
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "bitflags"
@@ -154,28 +193,41 @@ name = "blake2b_simd"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
-dependencies = ["arrayref", "arrayvec 0.5.2", "constant_time_eq"]
+dependencies = [
+ "arrayref",
+ "arrayvec 0.5.2",
+ "constant_time_eq",
+]
 
 [[package]]
 name = "block-buffer"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
-dependencies = ["generic-array"]
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "brownstone"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "030ea61398f34f1395ccbeb046fb68c87b631d1f34567fed0f0f11fa35d18d8d"
-dependencies = ["arrayvec 0.7.2"]
+dependencies = [
+ "arrayvec 0.7.2",
+]
 
 [[package]]
 name = "bstr"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
-dependencies = ["lazy_static", "memchr", "regex-automata", "serde"]
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+ "serde",
+]
 
 [[package]]
 name = "bumpalo"
@@ -212,14 +264,23 @@ name = "chrono"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
-dependencies = ["libc", "num-integer", "num-traits", "serde", "time", "winapi"]
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "serde",
+ "time",
+ "winapi",
+]
 
 [[package]]
 name = "cmake"
 version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8ad8cef104ac57b68b89df3208164d228503abbdce70f6880ffa3d970e7443a"
-dependencies = ["cc"]
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "constant_time_eq"
@@ -232,7 +293,10 @@ name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
-dependencies = ["core-foundation-sys", "libc"]
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -245,14 +309,19 @@ name = "cpufeatures"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
-dependencies = ["libc"]
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crossbeam-utils"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
-dependencies = ["cfg-if", "lazy_static"]
+dependencies = [
+ "cfg-if",
+ "lazy_static",
+]
 
 [[package]]
 name = "crossterm"
@@ -260,14 +329,14 @@ version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2102ea4f781910f8a5b98dd061f4c2023f479ce7bb1236330099ceb5a93cf17"
 dependencies = [
-  "bitflags",
-  "crossterm_winapi",
-  "libc",
-  "mio",
-  "parking_lot",
-  "signal-hook",
-  "signal-hook-mio",
-  "winapi",
+ "bitflags",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
 ]
 
 [[package]]
@@ -275,42 +344,63 @@ name = "crossterm_winapi"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c"
-dependencies = ["winapi"]
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crypto-common"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
-dependencies = ["generic-array", "typenum"]
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "csv"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
-dependencies = ["bstr", "csv-core", "itoa 0.4.8", "ryu", "serde"]
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa 0.4.8",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "csv-core"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
-dependencies = ["memchr"]
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "digest"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
-dependencies = ["block-buffer", "crypto-common", "subtle"]
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "dirs"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
-dependencies = ["libc", "redox_users", "winapi"]
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
 
 [[package]]
 name = "either"
@@ -329,68 +419,82 @@ name = "encoding_rs"
 version = "0.8.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dc8abb250ffdda33912550faa54c88ec8b998dec0b2c55ab224921ce11df"
-dependencies = ["cfg-if"]
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "esdl"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f8e2dc29153d44d99ce0e6bf06b2fd25d9a7ae59a1da53b6cb1706efbf5ac4"
-dependencies = ["heck", "nom", "nom-supreme", "serde", "thiserror"]
+dependencies = [
+ "heck 0.4.0",
+ "nom",
+ "nom-supreme",
+ "serde",
+ "thiserror",
+]
 
 [[package]]
 name = "eventstore"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6adac036ea9bd2f6860f24652fd6a2648fa889b4b764d1e929db727b8e28aa22"
+checksum = "023a2fff13ba0079e79ee102999e32112f3fed20e5b5c0bd64dfff64ab3fdf69"
 dependencies = [
-  "async-stream",
-  "base64",
-  "bitflags",
-  "byteorder",
-  "bytes",
-  "futures",
-  "http",
-  "log",
-  "nom",
-  "prost",
-  "prost-derive",
-  "prost-types",
-  "rand",
-  "reqwest",
-  "rustls 0.19.1",
-  "serde",
-  "serde_json",
-  "thiserror",
-  "tokio",
-  "tonic",
-  "tonic-build",
-  "tonic-types",
-  "urlencoding",
-  "uuid",
-  "webpki 0.21.4",
+ "async-stream",
+ "base64",
+ "bitflags",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "futures",
+ "http",
+ "log",
+ "nom",
+ "prost 0.9.0",
+ "prost-derive 0.9.0",
+ "prost-types 0.9.0",
+ "rand",
+ "reqwest",
+ "rustls 0.19.1",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tonic 0.6.2",
+ "tonic-build 0.6.2",
+ "tonic-types",
+ "urlencoding",
+ "uuid",
+ "webpki 0.21.4",
 ]
 
 [[package]]
 name = "example-bank-account"
 version = "0.1.0"
-dependencies = ["esdl", "serde", "thalo", "thalo-testing"]
+dependencies = [
+ "esdl",
+ "serde",
+ "thalo",
+ "thalo-testing",
+]
 
 [[package]]
 name = "example-protobuf"
 version = "0.1.0"
 dependencies = [
-  "crossterm",
-  "futures-util",
-  "prost",
-  "serde_json",
-  "text_io",
-  "thalo",
-  "thalo-inmemory",
-  "tokio",
-  "tokio-stream",
-  "tonic",
-  "tonic-build",
+ "crossterm",
+ "futures-util",
+ "prost 0.10.3",
+ "serde_json",
+ "text_io",
+ "thalo",
+ "thalo-inmemory",
+ "tokio",
+ "tokio-stream",
+ "tonic 0.7.2",
+ "tonic-build 0.7.2",
 ]
 
 [[package]]
@@ -404,7 +508,9 @@ name = "fastrand"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
-dependencies = ["instant"]
+dependencies = [
+ "instant",
+]
 
 [[package]]
 name = "fixedbitset"
@@ -423,7 +529,10 @@ name = "form_urlencoded"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
-dependencies = ["matches", "percent-encoding"]
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
 
 [[package]]
 name = "futures"
@@ -431,13 +540,13 @@ version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
 dependencies = [
-  "futures-channel",
-  "futures-core",
-  "futures-executor",
-  "futures-io",
-  "futures-sink",
-  "futures-task",
-  "futures-util",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
 ]
 
 [[package]]
@@ -445,7 +554,10 @@ name = "futures-channel"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
-dependencies = ["futures-core", "futures-sink"]
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
 
 [[package]]
 name = "futures-core"
@@ -458,7 +570,11 @@ name = "futures-executor"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
-dependencies = ["futures-core", "futures-task", "futures-util"]
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -471,7 +587,11 @@ name = "futures-macro"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
-dependencies = ["proc-macro2", "quote", "syn"]
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -491,16 +611,16 @@ version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
-  "futures-channel",
-  "futures-core",
-  "futures-io",
-  "futures-macro",
-  "futures-sink",
-  "futures-task",
-  "memchr",
-  "pin-project-lite",
-  "pin-utils",
-  "slab",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -508,21 +628,32 @@ name = "generic-array"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
-dependencies = ["typenum", "version_check"]
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = ["cfg-if", "libc", "wasi 0.9.0+wasi-snapshot-preview1"]
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
 
 [[package]]
 name = "getrandom"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
-dependencies = ["cfg-if", "libc", "wasi 0.10.2+wasi-snapshot-preview1"]
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.10.2+wasi-snapshot-preview1",
+]
 
 [[package]]
 name = "h2"
@@ -530,17 +661,17 @@ version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
 dependencies = [
-  "bytes",
-  "fnv",
-  "futures-core",
-  "futures-sink",
-  "futures-util",
-  "http",
-  "indexmap",
-  "slab",
-  "tokio",
-  "tokio-util 0.7.1",
-  "tracing",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util 0.7.1",
+ "tracing",
 ]
 
 [[package]]
@@ -548,6 +679,15 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "heck"
@@ -560,28 +700,40 @@ name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = ["libc"]
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = ["digest"]
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff8670570af52249509a86f5e3e18a08c60b177071826898fde8997cf5f6bfbb"
-dependencies = ["bytes", "fnv", "itoa 1.0.1"]
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa 1.0.1",
+]
 
 [[package]]
 name = "http-body"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
-dependencies = ["bytes", "http", "pin-project-lite"]
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "http-range-header"
@@ -607,22 +759,22 @@ version = "0.14.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b26ae0a80afebe130861d90abf98e3814a4f28a4c6ffeb5ab8ebb2be311e0ef2"
 dependencies = [
-  "bytes",
-  "futures-channel",
-  "futures-core",
-  "futures-util",
-  "h2",
-  "http",
-  "http-body",
-  "httparse",
-  "httpdate",
-  "itoa 1.0.1",
-  "pin-project-lite",
-  "socket2",
-  "tokio",
-  "tower-service",
-  "tracing",
-  "want",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa 1.0.1",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
 ]
 
 [[package]]
@@ -631,11 +783,11 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
 dependencies = [
-  "http",
-  "hyper",
-  "rustls 0.20.2",
-  "tokio",
-  "tokio-rustls 0.23.2",
+ "http",
+ "hyper",
+ "rustls 0.20.2",
+ "tokio",
+ "tokio-rustls 0.23.2",
 ]
 
 [[package]]
@@ -643,14 +795,23 @@ name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
-dependencies = ["hyper", "pin-project-lite", "tokio", "tokio-io-timeout"]
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
+]
 
 [[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
-dependencies = ["matches", "unicode-bidi", "unicode-normalization"]
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "indent_write"
@@ -663,14 +824,19 @@ name = "indexmap"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
-dependencies = ["autocfg", "hashbrown"]
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
 
 [[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = ["cfg-if"]
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "ipnet"
@@ -683,7 +849,9 @@ name = "itertools"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
-dependencies = ["either"]
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -708,7 +876,9 @@ name = "js-sys"
 version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04"
-dependencies = ["wasm-bindgen"]
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -727,40 +897,58 @@ name = "libz-sys"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e7e15d7610cce1d9752e137625f14e61a28cd45929b6e12e47b50fe154ee2e"
-dependencies = ["cc", "libc", "pkg-config", "vcpkg"]
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "lock_api"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
-dependencies = ["autocfg", "scopeguard"]
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = ["cfg-if"]
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "matches"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
+
+[[package]]
+name = "matchit"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
 
 [[package]]
 name = "md-5"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "658646b21e0b72f7866c7038ab086d3d5e1cd6271f060fd37defb241949d0582"
-dependencies = ["digest"]
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
-
-[[package]]
-name = "mime"
-version = "0.3.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "mime"
@@ -780,10 +968,10 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "713d550d9b44d89174e066b7a6217ae06234c10cb47819a88290d2b353c31799"
 dependencies = [
-  "libc",
-  "log",
-  "wasi 0.11.0+wasi-snapshot-preview1",
-  "windows-sys",
+ "libc",
+ "log",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys",
 ]
 
 [[package]]
@@ -797,56 +985,95 @@ name = "nom"
 version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
-dependencies = ["memchr", "minimal-lexical"]
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "nom-supreme"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aadc66631948f6b65da03be4c4cd8bd104d481697ecbb9bbd65719b1ec60bc9f"
-dependencies = ["brownstone", "indent_write", "joinery", "memchr", "nom"]
+dependencies = [
+ "brownstone",
+ "indent_write",
+ "joinery",
+ "memchr",
+ "nom",
+]
 
 [[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = ["autocfg", "num-traits"]
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
-dependencies = ["autocfg"]
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "num_cpus"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
-dependencies = ["hermit-abi", "libc"]
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
 
 [[package]]
 name = "num_enum"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf5395665662ef45796a4ff5486c5d41d29e0c09640af4c5f17fd94ee2c119c9"
-dependencies = ["num_enum_derive"]
+dependencies = [
+ "num_enum_derive",
+]
 
 [[package]]
 name = "num_enum_derive"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b0498641e53dd6ac1a4f22547548caa6864cc4933784319cd1775271c5a46ce"
-dependencies = ["proc-macro-crate", "proc-macro2", "quote", "syn"]
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "parking_lot"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
-dependencies = ["lock_api", "parking_lot_core"]
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
 
 [[package]]
 name = "parking_lot_core"
@@ -854,11 +1081,11 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
 dependencies = [
-  "cfg-if",
-  "libc",
-  "redox_syscall 0.2.13",
-  "smallvec",
-  "windows-sys",
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.2.13",
+ "smallvec",
+ "windows-sys",
 ]
 
 [[package]]
@@ -872,35 +1099,48 @@ name = "petgraph"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
-dependencies = ["fixedbitset", "indexmap"]
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
 
 [[package]]
 name = "phf"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
-dependencies = ["phf_shared"]
+dependencies = [
+ "phf_shared",
+]
 
 [[package]]
 name = "phf_shared"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
-dependencies = ["siphasher"]
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
-dependencies = ["pin-project-internal"]
+dependencies = [
+ "pin-project-internal",
+]
 
 [[package]]
 name = "pin-project-internal"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
-dependencies = ["proc-macro2", "quote", "syn"]
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -926,16 +1166,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "878c6cbf956e03af9aa8204b407b9cbf47c072164800aa918c516cd4b056c50c"
 dependencies = [
-  "base64",
-  "byteorder",
-  "bytes",
-  "fallible-iterator",
-  "hmac",
-  "md-5",
-  "memchr",
-  "rand",
-  "sha2",
-  "stringprep",
+ "base64",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "hmac",
+ "md-5",
+ "memchr",
+ "rand",
+ "sha2",
+ "stringprep",
 ]
 
 [[package]]
@@ -944,12 +1184,12 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebd6e8b7189a73169290e89bd24c771071f1012d8fe6f738f5226531f0b03d89"
 dependencies = [
-  "bytes",
-  "chrono",
-  "fallible-iterator",
-  "postgres-protocol",
-  "serde",
-  "serde_json",
+ "bytes",
+ "chrono",
+ "fallible-iterator",
+ "postgres-protocol",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -963,7 +1203,10 @@ name = "prettyplease"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9e07e3a46d0771a8a06b5f4441527802830b43e679ba12f44960f48dd4c6803"
-dependencies = ["proc-macro2", "syn"]
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "prettytable-rs"
@@ -971,12 +1214,12 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fd04b170004fa2daccf418a7f8253aaf033c27760b5f225889024cf66d7ac2e"
 dependencies = [
-  "atty",
-  "csv",
-  "encode_unicode",
-  "lazy_static",
-  "term",
-  "unicode-width",
+ "atty",
+ "csv",
+ "encode_unicode",
+ "lazy_static",
+ "term",
+ "unicode-width",
 ]
 
 [[package]]
@@ -984,7 +1227,10 @@ name = "proc-macro-crate"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
-dependencies = ["thiserror", "toml"]
+dependencies = [
+ "thiserror",
+ "toml",
+]
 
 [[package]]
 name = "proc-macro-error"
@@ -992,11 +1238,11 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
-  "proc-macro-error-attr",
-  "proc-macro2",
-  "quote",
-  "syn",
-  "version_check",
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
 ]
 
 [[package]]
@@ -1004,21 +1250,60 @@ name = "proc-macro-error-attr"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = ["proc-macro2", "quote", "version_check"]
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"
 version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9027b48e9d4c9175fa2218adf3557f91c1137021739951d4932f5f8268ac48aa"
-dependencies = ["unicode-xid"]
+dependencies = [
+ "unicode-xid",
+]
+
+[[package]]
+name = "prost"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
+dependencies = [
+ "bytes",
+ "prost-derive 0.9.0",
+]
 
 [[package]]
 name = "prost"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc03e116981ff7d8da8e5c220e374587b98d294af7ba7dd7fda761158f00086f"
-dependencies = ["bytes", "prost-derive"]
+dependencies = [
+ "bytes",
+ "prost-derive 0.10.1",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
+dependencies = [
+ "bytes",
+ "heck 0.3.3",
+ "itertools",
+ "lazy_static",
+ "log",
+ "multimap",
+ "petgraph",
+ "prost 0.9.0",
+ "prost-types 0.9.0",
+ "regex",
+ "tempfile",
+ "which",
+]
 
 [[package]]
 name = "prost-build"
@@ -1026,20 +1311,33 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65a1118354442de7feb8a2a76f3d80ef01426bd45542c8c1fdffca41a758f846"
 dependencies = [
-  "bytes",
-  "cfg-if",
-  "cmake",
-  "heck",
-  "itertools",
-  "lazy_static",
-  "log",
-  "multimap",
-  "petgraph",
-  "prost",
-  "prost-types",
-  "regex",
-  "tempfile",
-  "which",
+ "bytes",
+ "cfg-if",
+ "cmake",
+ "heck 0.4.0",
+ "itertools",
+ "lazy_static",
+ "log",
+ "multimap",
+ "petgraph",
+ "prost 0.10.3",
+ "prost-types 0.10.1",
+ "regex",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1047,42 +1345,72 @@ name = "prost-derive"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b670f45da57fb8542ebdbb6105a925fe571b67f9e7ed9f47a06a84e72b4e7cc"
-dependencies = ["anyhow", "itertools", "proc-macro2", "quote", "syn"]
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
+dependencies = [
+ "bytes",
+ "prost 0.9.0",
+]
 
 [[package]]
 name = "prost-types"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d0a014229361011dc8e69c8a1ec6c2e8d0f2af7c91e3ea3f5b2170298461e68"
-dependencies = ["bytes", "prost"]
+dependencies = [
+ "bytes",
+ "prost 0.10.3",
+]
 
 [[package]]
 name = "quote"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
-dependencies = ["proc-macro2"]
+dependencies = [
+ "proc-macro2",
+]
 
 [[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = ["libc", "rand_chacha", "rand_core"]
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
 
 [[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = ["ppv-lite86", "rand_core"]
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
 
 [[package]]
 name = "rand_core"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
-dependencies = ["getrandom 0.2.6"]
+dependencies = [
+ "getrandom 0.2.6",
+]
 
 [[package]]
 name = "rdkafka"
@@ -1090,15 +1418,15 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1de127f294f2dba488ed46760b129d5ecbeabbd337ccbf3739cb29d50db2161c"
 dependencies = [
-  "futures",
-  "libc",
-  "log",
-  "rdkafka-sys",
-  "serde",
-  "serde_derive",
-  "serde_json",
-  "slab",
-  "tokio",
+ "futures",
+ "libc",
+ "log",
+ "rdkafka-sys",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "slab",
+ "tokio",
 ]
 
 [[package]]
@@ -1106,7 +1434,12 @@ name = "rdkafka-sys"
 version = "4.2.0+1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e542c6863b04ce0fa0c5719bc6b7b348cf8dd21af1bb03c9db5f9805b2a6473"
-dependencies = ["libc", "libz-sys", "num_enum", "pkg-config"]
+dependencies = [
+ "libc",
+ "libz-sys",
+ "num_enum",
+ "pkg-config",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1119,21 +1452,31 @@ name = "redox_syscall"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
-dependencies = ["bitflags"]
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "redox_users"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
-dependencies = ["getrandom 0.1.16", "redox_syscall 0.1.57", "rust-argon2"]
+dependencies = [
+ "getrandom 0.1.16",
+ "redox_syscall 0.1.57",
+ "rust-argon2",
+]
 
 [[package]]
 name = "regex"
 version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
-dependencies = ["regex-syntax"]
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
 
 [[package]]
 name = "regex-automata"
@@ -1152,7 +1495,9 @@ name = "remove_dir_all"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = ["winapi"]
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "reqwest"
@@ -1160,37 +1505,37 @@ version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f242f1488a539a79bac6dbe7c8609ae43b7914b7736210f239a37cccb32525"
 dependencies = [
-  "base64",
-  "bytes",
-  "encoding_rs",
-  "futures-core",
-  "futures-util",
-  "h2",
-  "http",
-  "http-body",
-  "hyper",
-  "hyper-rustls",
-  "ipnet",
-  "js-sys",
-  "lazy_static",
-  "log",
-  "mime",
-  "percent-encoding",
-  "pin-project-lite",
-  "rustls 0.20.2",
-  "rustls-native-certs 0.6.1",
-  "rustls-pemfile",
-  "serde",
-  "serde_json",
-  "serde_urlencoded",
-  "tokio",
-  "tokio-rustls 0.23.2",
-  "url",
-  "wasm-bindgen",
-  "wasm-bindgen-futures",
-  "web-sys",
-  "webpki-roots",
-  "winreg",
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls 0.20.2",
+ "rustls-native-certs 0.6.1",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-rustls 0.23.2",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+ "winreg",
 ]
 
 [[package]]
@@ -1199,13 +1544,13 @@ version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
 dependencies = [
-  "cc",
-  "libc",
-  "once_cell",
-  "spin",
-  "untrusted",
-  "web-sys",
-  "winapi",
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -1213,21 +1558,37 @@ name = "rust-argon2"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb"
-dependencies = ["base64", "blake2b_simd", "constant_time_eq", "crossbeam-utils"]
+dependencies = [
+ "base64",
+ "blake2b_simd",
+ "constant_time_eq",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "rustls"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
-dependencies = ["base64", "log", "ring", "sct 0.6.1", "webpki 0.21.4"]
+dependencies = [
+ "base64",
+ "log",
+ "ring",
+ "sct 0.6.1",
+ "webpki 0.21.4",
+]
 
 [[package]]
 name = "rustls"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d37e5e2290f3e040b594b1a9e04377c2c671f1a1cfd9bfdef82106ac1c113f84"
-dependencies = ["log", "ring", "sct 0.7.0", "webpki 0.22.0"]
+dependencies = [
+ "log",
+ "ring",
+ "sct 0.7.0",
+ "webpki 0.22.0",
+]
 
 [[package]]
 name = "rustls-native-certs"
@@ -1235,10 +1596,10 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
 dependencies = [
-  "openssl-probe",
-  "rustls 0.19.1",
-  "schannel",
-  "security-framework",
+ "openssl-probe",
+ "rustls 0.19.1",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -1247,10 +1608,10 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca9ebdfa27d3fc180e42879037b5338ab1c040c06affd00d8338598e7800943"
 dependencies = [
-  "openssl-probe",
-  "rustls-pemfile",
-  "schannel",
-  "security-framework",
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -1258,7 +1619,9 @@ name = "rustls-pemfile"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
-dependencies = ["base64"]
+dependencies = [
+ "base64",
+]
 
 [[package]]
 name = "ryu"
@@ -1271,7 +1634,10 @@ name = "schannel"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
-dependencies = ["lazy_static", "winapi"]
+dependencies = [
+ "lazy_static",
+ "winapi",
+]
 
 [[package]]
 name = "scopeguard"
@@ -1284,14 +1650,20 @@ name = "sct"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
-dependencies = ["ring", "untrusted"]
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "sct"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
-dependencies = ["ring", "untrusted"]
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "security-framework"
@@ -1299,11 +1671,11 @@ version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
 dependencies = [
-  "bitflags",
-  "core-foundation",
-  "core-foundation-sys",
-  "libc",
-  "security-framework-sys",
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
 ]
 
 [[package]]
@@ -1311,63 +1683,94 @@ name = "security-framework-sys"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
-dependencies = ["core-foundation-sys", "libc"]
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "serde"
 version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
-dependencies = ["serde_derive"]
+dependencies = [
+ "serde_derive",
+]
 
 [[package]]
 name = "serde_derive"
 version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
-dependencies = ["proc-macro2", "quote", "syn"]
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "serde_json"
 version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
-dependencies = ["itoa 1.0.1", "ryu", "serde"]
+dependencies = [
+ "itoa 1.0.1",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = ["form_urlencoded", "itoa 1.0.1", "ryu", "serde"]
+dependencies = [
+ "form_urlencoded",
+ "itoa 1.0.1",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "sha2"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
-dependencies = ["cfg-if", "cpufeatures", "digest"]
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
 
 [[package]]
 name = "signal-hook"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "647c97df271007dcea485bb74ffdb57f2e683f1306c854f468a0c244badabf2d"
-dependencies = ["libc", "signal-hook-registry"]
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
 
 [[package]]
 name = "signal-hook-mio"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
-dependencies = ["libc", "mio", "signal-hook"]
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
 
 [[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
-dependencies = ["libc"]
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "siphasher"
@@ -1392,7 +1795,10 @@ name = "socket2"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
-dependencies = ["libc", "winapi"]
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "spin"
@@ -1405,7 +1811,10 @@ name = "stringprep"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee348cb74b87454fff4b551cbf727025810a004f88aeacae7f85b87f4e9a1c1"
-dependencies = ["unicode-bidi", "unicode-normalization"]
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "subtle"
@@ -1418,7 +1827,11 @@ name = "syn"
 version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04066589568b72ec65f42d65a1a52436e954b168773148893c020269563decf2"
-dependencies = ["proc-macro2", "quote", "unicode-xid"]
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
 
 [[package]]
 name = "sync_wrapper"
@@ -1432,12 +1845,12 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
-  "cfg-if",
-  "fastrand",
-  "libc",
-  "redox_syscall 0.2.13",
-  "remove_dir_all",
-  "winapi",
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall 0.2.13",
+ "remove_dir_all",
+ "winapi",
 ]
 
 [[package]]
@@ -1445,7 +1858,11 @@ name = "term"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
-dependencies = ["byteorder", "dirs", "winapi"]
+dependencies = [
+ "byteorder",
+ "dirs",
+ "winapi",
+]
 
 [[package]]
 name = "text_io"
@@ -1457,125 +1874,145 @@ checksum = "442f2674e6bd8489052b958e0eaebd89c26eefa3be9dc359d1e2ecccdc510f45"
 name = "thalo"
 version = "0.5.0"
 dependencies = [
-  "async-stream",
-  "async-trait",
-  "chrono",
-  "futures-util",
-  "prettytable-rs",
-  "serde",
-  "thalo-macros",
-  "thiserror",
-  "tokio-stream",
-  "tonic",
+ "async-stream",
+ "async-trait",
+ "chrono",
+ "futures-util",
+ "prettytable-rs",
+ "serde",
+ "thalo-macros",
+ "thiserror",
+ "tokio-stream",
+ "tonic 0.7.2",
 ]
 
 [[package]]
 name = "thalo-eventstoredb"
 version = "0.5.0"
 dependencies = [
-  "async-trait",
-  "chrono",
-  "eventstore",
-  "futures",
-  "prettytable-rs",
-  "serde",
-  "serde_json",
-  "thalo",
-  "thiserror",
-  "uuid",
+ "async-trait",
+ "chrono",
+ "eventstore",
+ "futures",
+ "prettytable-rs",
+ "serde",
+ "serde_json",
+ "thalo",
+ "thiserror",
+ "uuid",
 ]
 
 [[package]]
 name = "thalo-filestore"
 version = "0.5.0"
 dependencies = [
-  "async-trait",
-  "serde",
-  "serde_json",
-  "tempfile",
-  "thalo",
-  "thalo-inmemory",
-  "thiserror",
-  "tokio",
+ "async-trait",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thalo",
+ "thalo-inmemory",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]
 name = "thalo-inmemory"
 version = "0.5.0"
 dependencies = [
-  "async-trait",
-  "chrono",
-  "prettytable-rs",
-  "serde",
-  "serde_json",
-  "thalo",
-  "thiserror",
+ "async-trait",
+ "chrono",
+ "prettytable-rs",
+ "serde",
+ "serde_json",
+ "thalo",
+ "thiserror",
 ]
 
 [[package]]
 name = "thalo-kafka"
 version = "0.5.0"
 dependencies = [
-  "async-stream",
-  "async-trait",
-  "futures-util",
-  "rdkafka",
-  "serde",
-  "serde_json",
-  "thalo",
-  "thiserror",
-  "tracing",
+ "async-stream",
+ "async-trait",
+ "futures-util",
+ "rdkafka",
+ "serde",
+ "serde_json",
+ "thalo",
+ "thiserror",
+ "tracing",
 ]
 
 [[package]]
 name = "thalo-macros"
 version = "0.5.0"
-dependencies = ["better-bae", "heck", "proc-macro2", "quote", "syn"]
+dependencies = [
+ "better-bae",
+ "heck 0.4.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "thalo-postgres"
 version = "0.5.0"
 dependencies = [
-  "async-trait",
-  "bb8-postgres",
-  "serde",
-  "serde_json",
-  "thalo",
-  "thiserror",
+ "async-trait",
+ "bb8-postgres",
+ "serde",
+ "serde_json",
+ "thalo",
+ "thiserror",
 ]
 
 [[package]]
 name = "thalo-testing"
 version = "0.5.0"
-dependencies = ["thalo", "thiserror"]
+dependencies = [
+ "thalo",
+ "thiserror",
+]
 
 [[package]]
 name = "thiserror"
 version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
-dependencies = ["thiserror-impl"]
+dependencies = [
+ "thiserror-impl",
+]
 
 [[package]]
 name = "thiserror-impl"
 version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
-dependencies = ["proc-macro2", "quote", "syn"]
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "time"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
-dependencies = ["libc", "winapi"]
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
-dependencies = ["tinyvec_macros"]
+dependencies = [
+ "tinyvec_macros",
+]
 
 [[package]]
 name = "tinyvec_macros"
@@ -1589,17 +2026,17 @@ version = "1.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4903bf0427cf68dddd5aa6a93220756f8be0c34fcfa9f5e6191e103e15a31395"
 dependencies = [
-  "bytes",
-  "libc",
-  "memchr",
-  "mio",
-  "num_cpus",
-  "once_cell",
-  "parking_lot",
-  "pin-project-lite",
-  "socket2",
-  "tokio-macros",
-  "winapi",
+ "bytes",
+ "libc",
+ "memchr",
+ "mio",
+ "num_cpus",
+ "once_cell",
+ "parking_lot",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "winapi",
 ]
 
 [[package]]
@@ -1607,14 +2044,21 @@ name = "tokio-io-timeout"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
-dependencies = ["pin-project-lite", "tokio"]
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "tokio-macros"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
-dependencies = ["proc-macro2", "quote", "syn"]
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "tokio-postgres"
@@ -1622,21 +2066,21 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19c88a47a23c5d2dc9ecd28fb38fba5fc7e5ddc1fe64488ec145076b0c71c8ae"
 dependencies = [
-  "async-trait",
-  "byteorder",
-  "bytes",
-  "fallible-iterator",
-  "futures",
-  "log",
-  "parking_lot",
-  "percent-encoding",
-  "phf",
-  "pin-project-lite",
-  "postgres-protocol",
-  "postgres-types",
-  "socket2",
-  "tokio",
-  "tokio-util 0.7.1",
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "futures",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "socket2",
+ "tokio",
+ "tokio-util 0.7.1",
 ]
 
 [[package]]
@@ -1644,21 +2088,34 @@ name = "tokio-rustls"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
-dependencies = ["rustls 0.19.1", "tokio", "webpki 0.21.4"]
+dependencies = [
+ "rustls 0.19.1",
+ "tokio",
+ "webpki 0.21.4",
+]
 
 [[package]]
 name = "tokio-rustls"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a27d5f2b839802bd8267fa19b0530f5a08b9c08cd417976be2a65d130fe1c11b"
-dependencies = ["rustls 0.20.2", "tokio", "webpki 0.22.0"]
+dependencies = [
+ "rustls 0.20.2",
+ "tokio",
+ "webpki 0.22.0",
+]
 
 [[package]]
 name = "tokio-stream"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
-dependencies = ["futures-core", "pin-project-lite", "tokio", "tokio-util 0.6.9"]
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util 0.6.9",
+]
 
 [[package]]
 name = "tokio-util"
@@ -1666,12 +2123,12 @@ version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
 dependencies = [
-  "bytes",
-  "futures-core",
-  "futures-sink",
-  "log",
-  "pin-project-lite",
-  "tokio",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -1680,12 +2137,12 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0edfdeb067411dba2044da6d1cb2df793dd35add7888d73c16e3381ded401764"
 dependencies = [
-  "bytes",
-  "futures-core",
-  "futures-sink",
-  "pin-project-lite",
-  "tokio",
-  "tracing",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1693,7 +2150,42 @@ name = "toml"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
-dependencies = ["serde"]
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "tonic"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff08f4649d10a70ffa3522ca559031285d8e421d727ac85c60825761818f5d0a"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.9.0",
+ "prost-derive 0.9.0",
+ "rustls-native-certs 0.5.0",
+ "tokio",
+ "tokio-rustls 0.22.0",
+ "tokio-stream",
+ "tokio-util 0.6.9",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
+]
 
 [[package]]
 name = "tonic"
@@ -1701,32 +2193,42 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5be9d60db39854b30b835107500cf0aca0b0d14d6e1c3de124217c23a29c2ddb"
 dependencies = [
-  "async-stream",
-  "async-trait",
-  "axum",
-  "base64",
-  "bytes",
-  "futures-core",
-  "futures-util",
-  "h2",
-  "http",
-  "http-body",
-  "hyper",
-  "hyper-timeout",
-  "percent-encoding",
-  "pin-project",
-  "prost",
-  "prost-derive",
-  "rustls-native-certs 0.5.0",
-  "tokio",
-  "tokio-rustls 0.22.0",
-  "tokio-stream",
-  "tokio-util 0.7.1",
-  "tower",
-  "tower-layer",
-  "tower-service",
-  "tracing",
-  "tracing-futures",
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.10.3",
+ "prost-derive 0.10.1",
+ "tokio",
+ "tokio-stream",
+ "tokio-util 0.7.1",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9403f1bafde247186684b230dc6f38b5cd514584e8bec1dd32514be4745fa757"
+dependencies = [
+ "proc-macro2",
+ "prost-build 0.9.0",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1734,14 +2236,24 @@ name = "tonic-build"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9263bf4c9bfaae7317c1c2faf7f18491d2fe476f70c414b73bf5d445b00ffa1"
-dependencies = ["prettyplease", "proc-macro2", "prost-build", "quote", "syn"]
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build 0.10.3",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "tonic-types"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40815ef5651cdebb73618ab877c159da73867f5dd5efbe7a1d27fb1cb3c3c95b"
-dependencies = ["prost", "prost-build", "prost-types"]
+dependencies = [
+ "prost 0.9.0",
+ "prost-build 0.9.0",
+ "prost-types 0.9.0",
+]
 
 [[package]]
 name = "tower"
@@ -1749,18 +2261,18 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a89fd63ad6adf737582df5db40d286574513c69a11dac5214dc3b5603d6713e"
 dependencies = [
-  "futures-core",
-  "futures-util",
-  "indexmap",
-  "pin-project",
-  "pin-project-lite",
-  "rand",
-  "slab",
-  "tokio",
-  "tokio-util 0.7.1",
-  "tower-layer",
-  "tower-service",
-  "tracing",
+ "futures-core",
+ "futures-util",
+ "indexmap",
+ "pin-project",
+ "pin-project-lite",
+ "rand",
+ "slab",
+ "tokio",
+ "tokio-util 0.7.1",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1769,17 +2281,17 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d342c6d58709c0a6d48d48dabbb62d4ef955cf5f0f3bbfd845838e7ae88dbae"
 dependencies = [
-  "bitflags",
-  "bytes",
-  "futures-core",
-  "futures-util",
-  "http",
-  "http-body",
-  "http-range-header",
-  "pin-project-lite",
-  "tower",
-  "tower-layer",
-  "tower-service",
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-range-header",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -1800,11 +2312,11 @@ version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d0ecdcb44a79f0fe9844f0c4f33a342cbcbb5117de8001e6ba0dc2351327d09"
 dependencies = [
-  "cfg-if",
-  "log",
-  "pin-project-lite",
-  "tracing-attributes",
-  "tracing-core",
+ "cfg-if",
+ "log",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
 ]
 
 [[package]]
@@ -1812,21 +2324,30 @@ name = "tracing-attributes"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc6b8ad3567499f98a1db7a752b07a7c8c7c7c34c332ec00effb2b0027974b7c"
-dependencies = ["proc-macro2", "quote", "syn"]
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "tracing-core"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f54c8ca710e81886d498c2fd3331b56c93aa248d49de2222ad2742247c60072f"
-dependencies = ["lazy_static"]
+dependencies = [
+ "lazy_static",
+]
 
 [[package]]
 name = "tracing-futures"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = ["pin-project", "tracing"]
+dependencies = [
+ "pin-project",
+ "tracing",
+]
 
 [[package]]
 name = "try-lock"
@@ -1851,7 +2372,15 @@ name = "unicode-normalization"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
-dependencies = ["tinyvec"]
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-width"
@@ -1876,7 +2405,12 @@ name = "url"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
-dependencies = ["form_urlencoded", "idna", "matches", "percent-encoding"]
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+]
 
 [[package]]
 name = "urlencoding"
@@ -1889,7 +2423,10 @@ name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
-dependencies = ["getrandom 0.2.4", "serde"]
+dependencies = [
+ "getrandom 0.2.6",
+ "serde",
+]
 
 [[package]]
 name = "vcpkg"
@@ -1908,7 +2445,10 @@ name = "want"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
-dependencies = ["log", "try-lock"]
+dependencies = [
+ "log",
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -1923,18 +2463,136 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb6ec270a31b1d3c7e266b999739109abce8b6c87e4b31fcfcd788b65267395"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
+
+[[package]]
+name = "web-sys"
+version = "0.3.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d8de8415c823c8abd270ad483c6feeac771fad964890779f9a8cb24fbbc1bf"
+dependencies = [
+ "webpki 0.22.0",
+]
+
+[[package]]
 name = "which"
 version = "4.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c4fb54e6113b6a8772ee41c3404fb0301ac79604489467e0a9ce1f3e97c24ae"
-dependencies = ["either", "lazy_static", "libc"]
+dependencies = [
+ "either",
+ "lazy_static",
+ "libc",
+]
 
 [[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = ["winapi-i686-pc-windows-gnu", "winapi-x86_64-pc-windows-gnu"]
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -1947,3 +2605,55 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "winreg"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
+dependencies = [
+ "winapi",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1792,6 +1792,7 @@ dependencies = [
  "serde_json",
  "thalo",
  "thiserror",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitvec"
+version = "0.19.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55f93d0ef3363c364d5976646a38f04cf67cfe1d4c8d160cdea02cab2c116b33"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "blake2b_simd"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,6 +197,12 @@ dependencies = [
  "regex-automata",
  "serde",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 
 [[package]]
 name = "byteorder"
@@ -229,6 +247,22 @@ name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6888e10551bb93e424d8df1d07f1a8b4fceb0001a3a4b048bfc47554946f47b3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
@@ -346,10 +380,39 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "350fa3483cae7d2a5793d2e8c4aefd06dc17ca1de3d9fdbbd577451a2a0dc0e0"
 dependencies = [
- "nom",
+ "nom 7.1.0",
  "nom-supreme",
  "serde",
  "thiserror",
+]
+
+[[package]]
+name = "eventstore"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28db0beb21c0c9e7625ec205e967fd5bde790de29a3e8d167f771e0c2e64173f"
+dependencies = [
+ "async-trait",
+ "base64",
+ "byteorder",
+ "bytes",
+ "futures",
+ "http",
+ "log",
+ "nom 6.1.2",
+ "prost 0.7.0",
+ "prost-derive 0.7.0",
+ "prost-types 0.7.0",
+ "rand",
+ "rustls",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tonic 0.4.3",
+ "tonic-build 0.4.2",
+ "uuid",
+ "webpki",
 ]
 
 [[package]]
@@ -368,15 +431,15 @@ version = "0.1.0"
 dependencies = [
  "crossterm",
  "futures-util",
- "prost",
+ "prost 0.9.0",
  "serde_json",
  "text_io",
  "thalo",
  "thalo-inmemory",
  "tokio",
  "tokio-stream",
- "tonic",
- "tonic-build",
+ "tonic 0.6.2",
+ "tonic-build 0.6.2",
 ]
 
 [[package]]
@@ -396,6 +459,12 @@ dependencies = [
 
 [[package]]
 name = "fixedbitset"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
+
+[[package]]
+name = "fixedbitset"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
@@ -405,6 +474,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "funty"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
@@ -682,6 +757,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
@@ -708,10 +792,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72167d68f5fce3b8655487b8038691a3c9984ee769590f93f2a631f4ad64e4f5"
 
 [[package]]
+name = "js-sys"
+version = "0.3.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "lexical-core"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
+dependencies = [
+ "arrayvec 0.5.2",
+ "bitflags",
+ "cfg-if",
+ "ryu",
+ "static_assertions",
+]
 
 [[package]]
 name = "libc"
@@ -800,6 +906,19 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "nom"
+version = "6.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2"
+dependencies = [
+ "bitvec",
+ "funty",
+ "lexical-core",
+ "memchr",
+ "version_check",
+]
+
+[[package]]
+name = "nom"
 version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b1d11e1ef389c76fe5b81bcaf2ea32cf88b62bc494e19f493d0b30e7a930109"
@@ -819,7 +938,7 @@ dependencies = [
  "indent_write",
  "joinery",
  "memchr",
- "nom",
+ "nom 7.1.0",
 ]
 
 [[package]]
@@ -882,6 +1001,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -914,11 +1045,21 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "petgraph"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
+dependencies = [
+ "fixedbitset 0.2.0",
+ "indexmap",
+]
+
+[[package]]
+name = "petgraph"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.4.1",
  "indexmap",
 ]
 
@@ -1075,12 +1216,40 @@ dependencies = [
 
 [[package]]
 name = "prost"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
+dependencies = [
+ "bytes",
+ "prost-derive 0.7.0",
+]
+
+[[package]]
+name = "prost"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.9.0",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
+dependencies = [
+ "bytes",
+ "heck 0.3.3",
+ "itertools 0.9.0",
+ "log",
+ "multimap",
+ "petgraph 0.5.1",
+ "prost 0.7.0",
+ "prost-types 0.7.0",
+ "tempfile",
+ "which",
 ]
 
 [[package]]
@@ -1091,16 +1260,29 @@ checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
 dependencies = [
  "bytes",
  "heck 0.3.3",
- "itertools",
+ "itertools 0.10.3",
  "lazy_static",
  "log",
  "multimap",
- "petgraph",
- "prost",
- "prost-types",
+ "petgraph 0.6.0",
+ "prost 0.9.0",
+ "prost-types 0.9.0",
  "regex",
  "tempfile",
  "which",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
+dependencies = [
+ "anyhow",
+ "itertools 0.9.0",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1110,10 +1292,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.10.3",
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
+dependencies = [
+ "bytes",
+ "prost 0.7.0",
 ]
 
 [[package]]
@@ -1123,7 +1315,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
 dependencies = [
  "bytes",
- "prost",
+ "prost 0.9.0",
 ]
 
 [[package]]
@@ -1134,6 +1326,12 @@ checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
 
 [[package]]
 name = "rand"
@@ -1263,6 +1461,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "rust-argon2"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1275,16 +1488,84 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
+dependencies = [
+ "base64",
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
+dependencies = [
+ "openssl-probe",
+ "rustls",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
+name = "schannel"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+dependencies = [
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sct"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fed7948b6c68acbb6e20c334f55ad635dc0f75506963de4464289fbd3b051ac"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a57321bf8bc2362081b2599912d2961fe899c0efadf1b4b2f8d48b3e253bb96c"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "serde"
@@ -1387,6 +1668,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "stringprep"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1412,6 +1705,12 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -1457,7 +1756,21 @@ dependencies = [
  "thalo-macros",
  "thiserror",
  "tokio-stream",
- "tonic",
+ "tonic 0.6.2",
+]
+
+[[package]]
+name = "thalo-eventstoredb"
+version = "0.5.0"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "eventstore",
+ "futures",
+ "prettytable-rs",
+ "serde",
+ "serde_json",
+ "thalo",
 ]
 
 [[package]]
@@ -1640,6 +1953,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
+dependencies = [
+ "rustls",
+ "tokio",
+ "webpki",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1676,6 +2000,37 @@ dependencies = [
 
 [[package]]
 name = "tonic"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ac42cd97ac6bd2339af5bcabf105540e21e45636ec6fa6aae5e85d44db31be0"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.7.0",
+ "prost-derive 0.7.0",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tokio-util",
+ "tower",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "tonic"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff08f4649d10a70ffa3522ca559031285d8e421d727ac85c60825761818f5d0a"
@@ -1693,8 +2048,8 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost",
- "prost-derive",
+ "prost 0.9.0",
+ "prost-derive 0.9.0",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -1707,12 +2062,24 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c695de27302f4697191dda1c7178131a8cb805463dda02864acb80fe1322fdcf"
+dependencies = [
+ "proc-macro2",
+ "prost-build 0.7.0",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tonic-build"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9403f1bafde247186684b230dc6f38b5cd514584e8bec1dd32514be4745fa757"
 dependencies = [
  "proc-macro2",
- "prost-build",
+ "prost-build 0.9.0",
  "quote",
  "syn",
 ]
@@ -1839,6 +2206,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom 0.2.4",
+ "serde",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1873,6 +2256,80 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4203d69e40a52ee523b2529a773d5ffc1dc0071801c87b3d270b471b80ed01"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
+
+[[package]]
+name = "web-sys"
+version = "0.3.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "which"
 version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1904,3 +2361,9 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wyz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"

--- a/thalo-eventstoredb/Cargo.toml
+++ b/thalo-eventstoredb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "thalo-eventstoredb"
 version = "0.5.0"
-authors = ["Ari Seyhun <shearerbeard@gmail.com>"]
+authors = ["Mike Shearer <shearerbeard@gmail.com>"]
 edition = "2021"
 description = "EventStoreDB event store for crates.io/thalo"
 readme = "../README.md"

--- a/thalo-eventstoredb/Cargo.toml
+++ b/thalo-eventstoredb/Cargo.toml
@@ -23,7 +23,7 @@ exclude = ["/docker-image"]
 thiserror = "1.0"
 async-trait = "0.1"
 chrono = "0.4"
-eventstore = "2.0.0-alpha.1"
+eventstore = "2.0.0-alpha.2"
 futures = "0.3"
 prettytable-rs = { version = "0.8", optional = true }
 serde = "1.0"

--- a/thalo-eventstoredb/Cargo.toml
+++ b/thalo-eventstoredb/Cargo.toml
@@ -15,15 +15,12 @@ categories = [
   "rust-patterns",
   "web-programming::http-server",
 ]
-exclude = ["/docker-image"]
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 thiserror = "1.0"
 async-trait = "0.1"
 chrono = "0.4"
-eventstore = "2.0.0"
+eventstore = "2.1.0"
 futures = "0.3"
 prettytable-rs = { version = "0.8", optional = true }
 serde = "1.0"
@@ -32,7 +29,7 @@ thalo = { version = "0.5.0", path = "../thalo", features = [
   "event-store",
   "tests-cfg",
 ] }
-uuid = { version  = "0.8", features = [ "v4", "serde" ] }
+uuid = { version = "0.8", features = ["v4", "serde"] }
 
 [features]
 default = ["debug"]

--- a/thalo-eventstoredb/Cargo.toml
+++ b/thalo-eventstoredb/Cargo.toml
@@ -23,7 +23,7 @@ exclude = ["/docker-image"]
 thiserror = "1.0"
 async-trait = "0.1"
 chrono = "0.4"
-eventstore = "2.0.0-alpha.2"
+eventstore = "2.0.0"
 futures = "0.3"
 prettytable-rs = { version = "0.8", optional = true }
 serde = "1.0"

--- a/thalo-eventstoredb/Cargo.toml
+++ b/thalo-eventstoredb/Cargo.toml
@@ -20,9 +20,10 @@ exclude = ["/docker-image"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+thiserror = "1.0"
 async-trait = "0.1"
 chrono = "0.4"
-eventstore = "1.0.0"
+eventstore = "2.0.0-alpha.1"
 futures = "0.3"
 prettytable-rs = { version = "0.8", optional = true }
 serde = "1.0"

--- a/thalo-eventstoredb/Cargo.toml
+++ b/thalo-eventstoredb/Cargo.toml
@@ -20,7 +20,10 @@ exclude = ["/docker-image"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-trait = "0.1"
 chrono = "0.4"
+eventstore = "1.0.0"
+futures = "0.3"
 prettytable-rs = { version = "0.8", optional = true }
 serde = "1.0"
 serde_json = "1.0"

--- a/thalo-eventstoredb/Cargo.toml
+++ b/thalo-eventstoredb/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "thalo-eventstoredb"
+version = "0.5.0"
+authors = ["Ari Seyhun <shearerbeard@gmail.com>"]
+edition = "2021"
+description = "EventStoreDB event store for crates.io/thalo"
+readme = "../README.md"
+repository = "https://github.com/thalo-rs/thalo"
+license = "MIT OR Apache-2.0"
+keywords = ["event-sourcing", "cqrs", "event-driven", "actors", "macros"]
+categories = [
+  "database",
+  "data-structures",
+  "development-tools",
+  "rust-patterns",
+  "web-programming::http-server",
+]
+exclude = ["/docker-image"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+chrono = "0.4"
+prettytable-rs = { version = "0.8", optional = true }
+serde = "1.0"
+serde_json = "1.0"
+thalo = { version = "0.5.0", path = "../thalo", features = [
+  "event-store",
+  "tests-cfg",
+] }
+
+[features]
+default = ["debug"]
+debug = ["prettytable-rs"]

--- a/thalo-eventstoredb/Cargo.toml
+++ b/thalo-eventstoredb/Cargo.toml
@@ -32,6 +32,7 @@ thalo = { version = "0.5.0", path = "../thalo", features = [
   "event-store",
   "tests-cfg",
 ] }
+uuid = { version  = "0.8", features = [ "v4", "serde" ] }
 
 [features]
 default = ["debug"]

--- a/thalo-eventstoredb/README.md
+++ b/thalo-eventstoredb/README.md
@@ -1,0 +1,64 @@
+## EventStoreDB EventStore for Thalo
+
+Demo repo to be found [here](https://github.com/Shearerbeard/event-sourcing-pizza-delivery-demo-rs).
+
+### Example Useage
+```rust
+use eventstore::{Client, ClientSettings, SubscribeToAllOptions, SubscriptionFilter};
+use thalo_eventstoredb::{ESDBEventStore, ESDBEventPayload};
+use order::aggregate::Order;
+use order::projection::OrderProjection;
+use uuid::Uuid;
+
+#[derive(Debug)]
+pub enum Error {
+    CouldNotPlaceOrder(aggregate::Error),
+    EventStore(thalo_eventstoredb::Error),
+    NotFound,
+}
+
+// Initialize EventStoreDB EventStore
+let client = Client::new(
+        "esdb://localhost:2113?tls=false"
+            .parse::<ClientSettings>()
+            .unwrap(),
+    )
+    .unwrap();
+let orders_store = event_store: ESDBEventStore::new(client);
+
+
+// Initialize a Thalo Projection
+let orders_projection = OrderProjection::default()
+
+// Subscribe and hydrate your Thalo projections with ESDB's built in subs
+tokio::spawn(async move {
+    let sub_options = SubscribeToAllOptions::default()
+        .filter(SubscriptionFilter::on_stream_name().add_prefix("order"));
+
+    let mut sub = client.clone().subscribe_to_all(&sub_options).await;
+
+    loop {
+        let event = sub.next().await.unwrap();
+        let event_data = event.get_original_event();
+        let ee = event_data
+            .as_json::<ESDBEventPayload>()
+            .unwrap()
+            .event_envelope::<Order>(event_data.revision as usize)
+            .unwrap();
+
+        if orders_projection.handle(ee).await.is_ok() {
+            println!("Projection handled Sub Event!");
+        }
+    }
+});
+
+
+// Write an event
+let result = store.execute(Uuid::new_v4().to_string(), |order: &Order| {
+  order.order_placed(order_type.clone(), line_items.clone(), address.clone())
+})
+.await
+.map_err(Error::EventStore)?
+.map_err(Error::CouldNotPlaceOrder);
+
+```

--- a/thalo-eventstoredb/src/error.rs
+++ b/thalo-eventstoredb/src/error.rs
@@ -1,9 +1,13 @@
 use thiserror::Error;
 
+/// Error enum.
 #[derive(Debug, Error)]
 pub enum Error {
+    /// ESDB verion conflict for optimistic currency control  
+    /// https://developers.eventstore.com/clients/grpc/appending-events.html#handling-concurrency
     #[error("Wrong expected position for eventstore write {0}")]
     WrongExpectedVersion(#[from] eventstore::WrongExpectedVersion),
+    /// Error reading stream.
     #[error("Error Reading Stream {0}")]
     ReadStreamError(eventstore::Error),
     #[error("Error Writing Stream {1} at position {0}")]
@@ -17,6 +21,7 @@ pub enum Error {
     /// Unable to serialize event payload.
     #[error("Serialize eventstore::EventData payload error: {0}")]
     SerializeEventDataPayload(serde_json::Error),
+    /// ESDB internal error. 
     #[error("Thalo event_store encountered EventStoreDB error {0}")]
     EventStoreDBError(#[from] eventstore::Error),
 }

--- a/thalo-eventstoredb/src/error.rs
+++ b/thalo-eventstoredb/src/error.rs
@@ -12,5 +12,5 @@ pub enum Error {
     SerializeEvent(serde_json::Error),
 
     #[error("Error converting event payload to byte array: {0}")]
-    Infallible(eventstore::Error)
+    EventStoreError(eventstore::Error),
 }

--- a/thalo-eventstoredb/src/error.rs
+++ b/thalo-eventstoredb/src/error.rs
@@ -3,15 +3,16 @@ use thiserror::Error;
 /// Error enum.
 #[derive(Debug, Error)]
 pub enum Error {
-    /// ESDB verion conflict for optimistic currency control  
-    /// https://developers.eventstore.com/clients/grpc/appending-events.html#handling-concurrency
+    /// ESDB verion conflict for optimistic currency control.
+    ///
+    /// See https://developers.eventstore.com/clients/grpc/appending-events.html#handling-concurrency
     #[error("Wrong expected position for eventstore write {0}")]
     WrongExpectedVersion(#[from] eventstore::WrongExpectedVersion),
     /// Error reading stream.
     #[error("Error Reading Stream {0}")]
     ReadStreamError(eventstore::Error),
     #[error("Error Writing Stream {1} at position {0}")]
-    WriteStreamError(usize, eventstore::Error),
+    WriteStreamError(u64, eventstore::Error),
     /// Deserialize event error.
     #[error("Deserialize event error: {0}")]
     DeserializeEvent(serde_json::Error),
@@ -21,7 +22,7 @@ pub enum Error {
     /// Unable to serialize event payload.
     #[error("Serialize eventstore::EventData payload error: {0}")]
     SerializeEventDataPayload(serde_json::Error),
-    /// ESDB internal error. 
+    /// ESDB internal error.
     #[error("Thalo event_store encountered EventStoreDB error {0}")]
     EventStoreDBError(#[from] eventstore::Error),
 }

--- a/thalo-eventstoredb/src/error.rs
+++ b/thalo-eventstoredb/src/error.rs
@@ -7,4 +7,10 @@ pub enum Error {
 
     #[error("Wrong Expected Version Error: {0}")]
     WrongExpectedVersion(usize),
+
+    #[error("serialize event error: {0}")]
+    SerializeEvent(serde_json::Error),
+
+    #[error("Error converting event payload to byte array: {0}")]
+    Infallible(eventstore::Error)
 }

--- a/thalo-eventstoredb/src/error.rs
+++ b/thalo-eventstoredb/src/error.rs
@@ -1,0 +1,10 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error(transparent)]
+    ReadStreamError(#[from] eventstore::Error),
+
+    #[error("Wrong Expected Version Error: {0}")]
+    WrongExpectedVersion(usize),
+}

--- a/thalo-eventstoredb/src/error.rs
+++ b/thalo-eventstoredb/src/error.rs
@@ -2,15 +2,21 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error(transparent)]
-    ReadStreamError(#[from] eventstore::Error),
-
-    #[error("Wrong Expected Version Error: {0}")]
-    WrongExpectedVersion(usize),
-
-    #[error("serialize event error: {0}")]
+    #[error("Wrong expected position for eventstore write {0}")]
+    WrongExpectedVersion(#[from] eventstore::WrongExpectedVersion),
+    #[error("Error Reading Stream {0}")]
+    ReadStreamError(eventstore::Error),
+    #[error("Error Writing Stream {1} at position {0}")]
+    WriteStreamError(usize, eventstore::Error),
+    /// Deserialize event error.
+    #[error("Deserialize event error: {0}")]
+    DeserializeEvent(serde_json::Error),
+    /// Unable to serialize event.
+    #[error("Serialize event error: {0}")]
     SerializeEvent(serde_json::Error),
-
-    #[error("Error converting event payload to byte array: {0}")]
-    EventStoreError(eventstore::Error),
+    /// Unable to serialize event payload.
+    #[error("Serialize eventstore::EventData payload error: {0}")]
+    SerializeEventDataPayload(serde_json::Error),
+    #[error("Thalo event_store encountered EventStoreDB error {0}")]
+    EventStoreDBError(#[from] eventstore::Error),
 }

--- a/thalo-eventstoredb/src/event_store.rs
+++ b/thalo-eventstoredb/src/event_store.rs
@@ -18,7 +18,7 @@ use uuid::Uuid;
 use crate::Error;
 
 #[derive(Serialize, Deserialize, Debug)]
-struct ESDBEventPayload {
+pub struct ESDBEventPayload {
     created_at: DateTime<Utc>,
     aggregate_type: String,
     aggregate_id: String,
@@ -26,7 +26,7 @@ struct ESDBEventPayload {
 }
 
 impl ESDBEventPayload {
-    fn event_envelope<A>(&self, id: usize) -> Result<AggregateEventEnvelope<A>, Error>
+    pub fn event_envelope<A>(&self, id: usize) -> Result<AggregateEventEnvelope<A>, Error>
     where
         A: Aggregate,
         <A as Aggregate>::Event: DeserializeOwned,

--- a/thalo-eventstoredb/src/event_store.rs
+++ b/thalo-eventstoredb/src/event_store.rs
@@ -36,7 +36,7 @@ impl ESDBEventPayload {
             created_at: self.created_at.into(),
             aggregate_type: self.aggregate_type.to_string(),
             aggregate_id: self.aggregate_id.clone(),
-            sequence: id.clone(),
+            sequence: id,
             event: serde_json::from_value(self.event_data.clone())
                 .map_err(Error::DeserializeEvent)?,
         })
@@ -158,7 +158,7 @@ impl EventStore for ESDBEventStore {
         while let Some(event) = result.next().await? {
             let event_data = event.get_original_event();
 
-            if event_data.event_type.starts_with("$") {
+            if event_data.event_type.starts_with('$') {
                 continue;
             }
 
@@ -198,7 +198,7 @@ impl EventStore for ESDBEventStore {
             .max_count(1);
 
         let events = self.read_stream(self.stream_id::<A>(Some(id)), options).await?;
-        if let Some(event) = events.iter().next() {
+        if let Some(event) = events.get(0) {
             let event_data = event.get_original_event();
             return Ok(Some(event_data.revision as usize));
         }
@@ -281,7 +281,7 @@ impl ESDBEventStore {
             while let Some(event) = stream.next().await.unwrap() {
                 let event_data = event.get_original_event();
 
-                if event_data.event_type.starts_with("$") {
+                if event_data.event_type.starts_with('$') {
                     continue;
                 }
 

--- a/thalo-eventstoredb/src/event_store.rs
+++ b/thalo-eventstoredb/src/event_store.rs
@@ -17,7 +17,7 @@ use uuid::Uuid;
 
 use crate::Error;
 
-#[derive(Serialize, Deserialize, )]
+#[derive(Serialize, Deserialize)]
 struct ESDBEventPayload {
     created_at: DateTime<Utc>,
     aggregate_type: String,
@@ -43,18 +43,18 @@ impl ESDBEventPayload {
     }
 }
 
-pub struct EventStoreDBEventStore {
+pub struct ESDBEventStore {
     pub client: Client,
 }
 
-impl EventStoreDBEventStore {
+impl ESDBEventStore {
     pub fn new(client: Client) -> Self {
-        EventStoreDBEventStore { client }
+        ESDBEventStore { client }
     }
 }
 
 #[async_trait]
-impl EventStore for EventStoreDBEventStore {
+impl EventStore for ESDBEventStore {
     type Error = Error;
 
     async fn load_events<A>(

--- a/thalo-eventstoredb/src/event_store.rs
+++ b/thalo-eventstoredb/src/event_store.rs
@@ -181,7 +181,7 @@ impl EventStore for EventStoreDBEventStore {
         let sequence = self.load_aggregate_sequence::<A>(id).await?;
         let mut event_ids = Vec::with_capacity(events.len());
 
-        let sequence = sequence.map(|sequence| sequence + 1).unwrap_or(0);
+        let sequence = sequence.unwrap_or(0);
         let revision = u64::try_from(sequence).unwrap();
         let options =
             AppendToStreamOptions::default().expected_revision(ExpectedRevision::Exact(revision));

--- a/thalo-eventstoredb/src/event_store.rs
+++ b/thalo-eventstoredb/src/event_store.rs
@@ -1,46 +1,33 @@
 use std::vec;
 
 use async_trait::async_trait;
-use eventstore::{All, Client, ClientSettings};
-use futures::TryStreamExt;
+use chrono::Utc;
+use eventstore::{
+    All, AppendToStreamOptions, Client, ExpectedRevision, ReadStreamOptions, ResolvedEvent, Single,
+    StreamPosition,
+};
 use serde::de::DeserializeOwned;
 use thalo::{
-    aggregate::Aggregate,
+    aggregate::{Aggregate, TypeId},
     event::{AggregateEventEnvelope, EventEnvelope},
     event_store::EventStore,
 };
 
-// pub enum Error {
-//     ESDBError,
-// }
+use crate::Error;
 
-// #[derive(Debug, Deserialize, Serialize)]
-// pub struct EventRecord {
-//     created_at: DateTime<Utc>,
-//     aggregate_type: String,
-//     aggregate_id: String,
-//     sequence: usize,
-//     event_data: serde_json::Value,
-// }
-
-// #[derive(Debug)]
 pub struct EventStoreDBEventStore {
-    /// Raw events stored in memory.
     pub client: Client,
-    pub stream: String,
 }
 
 impl EventStoreDBEventStore {
-    pub async fn new(settings: ClientSettings, stream: String) -> Self {
-        let client = Client::create(settings).await.unwrap();
-
-        EventStoreDBEventStore { client, stream }
+    pub fn new(client: Client) -> Self {
+        EventStoreDBEventStore { client }
     }
 }
 
 #[async_trait]
 impl EventStore for EventStoreDBEventStore {
-    type Error = eventstore::Error;
+    type Error = Error;
 
     async fn load_events<A>(
         &self,
@@ -50,25 +37,127 @@ impl EventStore for EventStoreDBEventStore {
         A: Aggregate,
         <A as Aggregate>::Event: DeserializeOwned,
     {
-        let result = self
+        let mut stream = <A as TypeId>::type_id().to_owned();
+
+        if let Some(id_str) = id {
+            stream.push_str(&String::from(":"));
+            stream.push_str(&id_str.to_string());
+        }
+
+        let mut stream = self
             .client
-            .read_stream(self.stream, &Default::default(), All)
+            .read_stream(stream, &Default::default(), All)
             .await?;
 
         let mut rv: Vec<EventEnvelope<A::Event>> = vec![];
 
-        if let Some(mut events) = result.ok() {
-            while let Some(event) = events.try_next().await? {
-                let event_data_result = event
-                    .get_original_event()
-                    .as_json::<EventEnvelope<A::Event>>();
-                match event_data_result {
-                    Ok(data) => rv.push(data),
-                    _ => (),
-                }
+        while let Some(event) = stream.next().await? {
+            let event_data_result = event
+                .get_original_event()
+                .as_json::<EventEnvelope<A::Event>>();
+
+            if let Ok(data) = event_data_result {
+                rv.push(data)
             }
         }
 
         return Ok(rv);
+    }
+
+    async fn load_events_by_id<A>(
+        &self,
+        ids: &[usize],
+    ) -> Result<Vec<AggregateEventEnvelope<A>>, Self::Error>
+    where
+        A: Aggregate,
+        <A as Aggregate>::Event: DeserializeOwned,
+    {
+        todo!()
+    }
+
+    async fn load_aggregate_sequence<A>(
+        &self,
+        id: &<A as Aggregate>::ID,
+    ) -> Result<Option<usize>, Self::Error>
+    where
+        A: Aggregate,
+    {
+        let mut stream = <A as TypeId>::type_id().to_owned();
+        stream.push_str(&String::from(":"));
+        stream.push_str(&id.to_string());
+
+        let options = ReadStreamOptions::default().position(StreamPosition::End);
+
+        let last_event = self.client.read_stream(&stream, &options, Single).await?;
+
+        if let Ok(Some(ResolvedEvent {
+            event,
+            link,
+            commit_position: Some(commit_position),
+        })) = last_event
+        {
+            if let Ok(s) = usize::try_from(commit_position) {
+                return Ok(Some(s));
+            }
+        }
+
+        Ok(None)
+    }
+
+    async fn save_events<A>(
+        &self,
+        id: &<A as Aggregate>::ID,
+        events: &[<A as Aggregate>::Event],
+    ) -> Result<Vec<usize>, Self::Error>
+    where
+        A: Aggregate,
+        <A as Aggregate>::Event: serde::Serialize,
+    {
+        if events.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let mut stream = <A as TypeId>::type_id().to_owned();
+        stream.push_str(&String::from(":"));
+        stream.push_str(&id.to_string());
+
+        let sequence = self.load_aggregate_sequence::<A>(id).await?;
+        let mut event_ids = Vec::with_capacity(events.len());
+
+        let sequence = sequence.map(|sequence| sequence + 1).unwrap_or(0);
+        let revision = u64::try_from(sequence).unwrap();
+        let options =
+            AppendToStreamOptions::default().expected_revision(ExpectedRevision::Exact(revision));
+
+        let res = self
+            .client
+            .append_to_stream(
+                &stream,
+                &options,
+                events.iter().enumerate().map(|(index, event)| {
+                    let created_at = Utc::now();
+                    let aggregate_type = <A as TypeId>::type_id().to_string();
+                    let aggregate_id = id.to_string();
+                    let sequence = sequence.clone() + index;
+                    let id = sequence.clone();
+                    event_ids.push(id.clone());
+
+                    AggregateEventEnvelope {
+                        id,
+                        aggregate_id,
+                        aggregate_type,
+                        sequence,
+                        event,
+                        created_at: created_at.into(),
+                    }
+                }),
+            )
+            .await;
+
+        if let Ok(Ok(_)) = res {
+            return Ok(event_ids);
+        } else {
+            return Err(Error::WrongExpectedVersion(sequence));
+        }
     }
 }

--- a/thalo-eventstoredb/src/event_store.rs
+++ b/thalo-eventstoredb/src/event_store.rs
@@ -220,6 +220,9 @@ impl ESDBEventStore {
                 continue;
             }
 
+            // TODO: Make ESDBEventPayload handle all this
+            // and implement fns for RecordedEvent -> ESDBEventPayload, ESDBEventPayload -> AggregateEnvelope, ESDBPayload -> eventstore::EventData
+            // make base struct handle id and revision seperately - update event trait for different id types (str, u64, uuid) etc
             events.push((
                 event_data.id,
                 event_data.revision,

--- a/thalo-eventstoredb/src/event_store.rs
+++ b/thalo-eventstoredb/src/event_store.rs
@@ -61,7 +61,7 @@ impl ESDBEventStore {
         let mut stream = <A as TypeId>::type_id().to_owned();
 
         if let Some(id_str) = id {
-            stream.push_str("-");
+            stream.push('-');
             stream.push_str(&id_str.to_string());
         }
 

--- a/thalo-eventstoredb/src/event_store.rs
+++ b/thalo-eventstoredb/src/event_store.rs
@@ -18,7 +18,7 @@ use uuid::Uuid;
 
 use crate::Error;
 
-/// Event payload for Event Store (ESDB) event store implementation
+/// Event payload for EventStoreDB (ESDB) event store implementation
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ESDBEventPayload {
     created_at: DateTime<Utc>,
@@ -46,13 +46,13 @@ impl ESDBEventPayload {
     }
 }
 
-/// An event store backed by the Event Store Database (aliased ESDB).
+/// An event store backed by the EventStoreDB Database (aliased ESDB).
 /// https://www.eventstore.com/eventstoredb
 ///
 /// See [crate] documentation for more info.
 #[derive(Clone)]
 pub struct ESDBEventStore {
-    /// Event Store (ESDB) client instance
+    /// EventStoreDB (ESDB) client instance
     client: Client,
 }
 

--- a/thalo-eventstoredb/src/event_store.rs
+++ b/thalo-eventstoredb/src/event_store.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use eventstore::{
     All, AppendToStreamOptions, Client, EventData, ExpectedRevision, ReadStreamOptions, Single,
-    StreamPosition
+    StreamPosition,
 };
 use futures::TryFutureExt;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -220,11 +220,11 @@ impl ESDBEventStore {
                 continue;
             }
 
-            events.push((event_data.id,
-                         event_data.revision,
-                         event_data
-                         .as_json::<ESDBEventPayload>()
-                         .unwrap()));
+            events.push((
+                event_data.id,
+                event_data.revision,
+                event_data.as_json::<ESDBEventPayload>().unwrap(),
+            ));
         }
 
         let mut table = prettytable::Table::new();

--- a/thalo-eventstoredb/src/event_store.rs
+++ b/thalo-eventstoredb/src/event_store.rs
@@ -1,0 +1,19 @@
+use std::sync::RwLock;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct EventRecord {
+    created_at: DateTime<Utc>,
+    aggregate_type: String,
+    aggregate_id: String,
+    sequence: usize,
+    event_data: serde_json::Value,
+}
+
+#[derive(Debug, Default)]
+pub struct EventStoreDBEventStore {
+    /// Raw events stored in memory.
+    pub events: RwLock<Vec<EventRecord>>,
+}

--- a/thalo-eventstoredb/src/event_store.rs
+++ b/thalo-eventstoredb/src/event_store.rs
@@ -1,19 +1,74 @@
-use std::sync::RwLock;
+use std::vec;
 
-use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
+use async_trait::async_trait;
+use eventstore::{All, Client, ClientSettings};
+use futures::TryStreamExt;
+use serde::de::DeserializeOwned;
+use thalo::{
+    aggregate::Aggregate,
+    event::{AggregateEventEnvelope, EventEnvelope},
+    event_store::EventStore,
+};
 
-#[derive(Debug, Deserialize, Serialize)]
-pub struct EventRecord {
-    created_at: DateTime<Utc>,
-    aggregate_type: String,
-    aggregate_id: String,
-    sequence: usize,
-    event_data: serde_json::Value,
-}
+// pub enum Error {
+//     ESDBError,
+// }
 
-#[derive(Debug, Default)]
+// #[derive(Debug, Deserialize, Serialize)]
+// pub struct EventRecord {
+//     created_at: DateTime<Utc>,
+//     aggregate_type: String,
+//     aggregate_id: String,
+//     sequence: usize,
+//     event_data: serde_json::Value,
+// }
+
+// #[derive(Debug)]
 pub struct EventStoreDBEventStore {
     /// Raw events stored in memory.
-    pub events: RwLock<Vec<EventRecord>>,
+    pub client: Client,
+    pub stream: String,
+}
+
+impl EventStoreDBEventStore {
+    pub async fn new(settings: ClientSettings, stream: String) -> Self {
+        let client = Client::create(settings).await.unwrap();
+
+        EventStoreDBEventStore { client, stream }
+    }
+}
+
+#[async_trait]
+impl EventStore for EventStoreDBEventStore {
+    type Error = eventstore::Error;
+
+    async fn load_events<A>(
+        &self,
+        id: Option<&<A as Aggregate>::ID>,
+    ) -> Result<Vec<AggregateEventEnvelope<A>>, Self::Error>
+    where
+        A: Aggregate,
+        <A as Aggregate>::Event: DeserializeOwned,
+    {
+        let result = self
+            .client
+            .read_stream(self.stream, &Default::default(), All)
+            .await?;
+
+        let mut rv: Vec<EventEnvelope<A::Event>> = vec![];
+
+        if let Some(mut events) = result.ok() {
+            while let Some(event) = events.try_next().await? {
+                let event_data_result = event
+                    .get_original_event()
+                    .as_json::<EventEnvelope<A::Event>>();
+                match event_data_result {
+                    Ok(data) => rv.push(data),
+                    _ => (),
+                }
+            }
+        }
+
+        return Ok(rv);
+    }
 }

--- a/thalo-eventstoredb/src/event_store.rs
+++ b/thalo-eventstoredb/src/event_store.rs
@@ -1,4 +1,4 @@
-// #![deny(missing_docs)]
+#![deny(missing_docs)]
 use std::{fmt::Debug, vec};
 
 use async_trait::async_trait;

--- a/thalo-eventstoredb/src/event_store.rs
+++ b/thalo-eventstoredb/src/event_store.rs
@@ -131,7 +131,7 @@ impl EventStore for EventStoreDBEventStore {
 
         let res = self
             .client
-            .append_to_stream(
+            .append_to_stream( // TODO: Implement eventstore::ToEvents trait for <Vec<A as Aggregate>::Event>
                 &stream,
                 &options,
                 events.iter().enumerate().map(|(index, event)| {

--- a/thalo-eventstoredb/src/event_store.rs
+++ b/thalo-eventstoredb/src/event_store.rs
@@ -61,7 +61,7 @@ impl ESDBEventStore {
         let mut stream = <A as TypeId>::type_id().to_owned();
 
         if let Some(id_str) = id {
-            stream.push_str(&String::from("-"));
+            stream.push_str("-");
             stream.push_str(&id_str.to_string());
         }
 

--- a/thalo-eventstoredb/src/event_store.rs
+++ b/thalo-eventstoredb/src/event_store.rs
@@ -17,7 +17,7 @@ use uuid::Uuid;
 
 use crate::Error;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 struct ESDBEventPayload {
     created_at: DateTime<Utc>,
     aggregate_type: String,
@@ -51,6 +51,23 @@ impl ESDBEventStore {
     pub fn new(client: Client) -> Self {
         ESDBEventStore { client }
     }
+
+    fn stream_id<A>(
+        &self,
+        id: Option<&<A as Aggregate>::ID>
+    ) -> String
+    where
+        A: Aggregate
+    {
+        let mut stream = <A as TypeId>::type_id().to_owned();
+
+        if let Some(id_str) = id {
+            stream.push_str(&String::from("-"));
+            stream.push_str(&id_str.to_string());
+        }
+
+        stream
+    }
 }
 
 #[async_trait]
@@ -65,33 +82,25 @@ impl EventStore for ESDBEventStore {
         A: Aggregate,
         <A as Aggregate>::Event: DeserializeOwned,
     {
-        let mut stream = <A as TypeId>::type_id().to_owned();
-
-        if let Some(id_str) = id {
-            stream.push_str(&String::from(":"));
-            stream.push_str(&id_str.to_string());
-        }
+        let mut result = self
+            .client
+            .read_stream(self.stream_id::<A>(id), &Default::default(), All)
+            .await
+            .map_err(Error::ReadStreamError)?;
 
         let mut rv: Vec<AggregateEventEnvelope<A>> = vec![];
-        let result = self
-            .client
-            .read_stream(stream, &Default::default(), All)
-            .await;
 
-        if let Ok(mut stream) = result {
-            while let Some(event) = stream.next().await? {
-                let event_data = event.get_original_event();
+        while let Some(event) = result.next().await? {
+            let event_data = event.get_original_event();
 
-                // TODO: - can we try event eventlope ids as uuid in addition to usize?
-                // let uuid = event_data.id.clone();
-                let sequence = usize::try_from(event_data.revision).unwrap();
-                let event_payload = event_data
-                    .as_json::<ESDBEventPayload>()
-                    .map_err(Error::DeserializeEvent)?
-                    .event_envelope::<A>(sequence)?;
+            // TODO: - can we try event eventlope ids as uuid in addition to usize?
+            // let uuid = event_data.id.clone();
+            let event_payload = event_data
+                .as_json::<ESDBEventPayload>()
+                .map_err(Error::DeserializeEvent)?
+                .event_envelope::<A>(event_data.revision as usize)?;
 
-                rv.push(event_payload);
-            }
+            rv.push(event_payload);
         }
 
         Ok(rv)
@@ -105,29 +114,28 @@ impl EventStore for ESDBEventStore {
         A: Aggregate,
         <A as Aggregate>::Event: DeserializeOwned,
     {
-        let stream = <A as TypeId>::type_id().to_owned();
+
+        let mut result = self
+            .client
+            .read_stream(self.stream_id::<A>(None), &Default::default(), All)
+            .await
+            .map_err(Error::ReadStreamError)?;
+
         let mut rv: Vec<AggregateEventEnvelope<A>> = vec![];
 
-        let result = self
-            .client
-            .read_stream(stream, &Default::default(), All)
-            .await;
+        while let Some(event) = result.next().await? {
+            let event_data = event.get_original_event();
 
-        if let Ok(mut stream) = result {
-            while let Some(event) = stream.next().await? {
-                let event_data = event.get_original_event();
+            // TODO: - can we try event eventlope ids as uuid in addition to usize?
+            // let uuid = event_data.id.clone();
+            let sequence = usize::try_from(event_data.revision).unwrap();
+            if ids.contains(&sequence) {
+                let event_payload = event_data
+                    .as_json::<ESDBEventPayload>()
+                    .map_err(Error::DeserializeEvent)?
+                    .event_envelope::<A>(sequence)?;
 
-                // TODO: - can we try event eventlope ids as uuid in addition to usize?
-                // let uuid = event_data.id.clone();
-                let sequence = usize::try_from(event_data.revision).unwrap();
-                if ids.contains(&sequence) {
-                    let event_payload = event_data
-                        .as_json::<ESDBEventPayload>()
-                        .map_err(Error::DeserializeEvent)?
-                        .event_envelope::<A>(sequence)?;
-
-                    rv.push(event_payload);
-                }
+                rv.push(event_payload);
             }
         }
 
@@ -141,24 +149,19 @@ impl EventStore for ESDBEventStore {
     where
         A: Aggregate,
     {
-        let mut stream = <A as TypeId>::type_id().to_owned();
-        stream.push_str(&String::from(":"));
-        stream.push_str(&id.to_string());
-
         let options = ReadStreamOptions::default().position(StreamPosition::End);
-
-        let last_event = self
+        let result = self
             .client
-            .read_stream(&stream, &options, Single)
-            .map_err(Error::ReadStreamError)
-            .await?;
+            .read_stream(self.stream_id::<A>(Some(id)), &options, Single)
+            .await
+            .map_err(Error::ReadStreamError)?;
 
-        if let Ok(Some(event)) = last_event {
+        if let Ok(Some(event)) = result {
             let event_data = event.get_original_event();
-            Ok(Some(usize::try_from(event_data.revision).unwrap()))
-        } else {
-            Ok(None)
+            return Ok(Some(event_data.revision as usize))
         }
+
+        Ok(None)
     }
 
     async fn save_events<A>(
@@ -174,34 +177,15 @@ impl EventStore for ESDBEventStore {
             return Ok(vec![]);
         }
 
-        let mut stream = <A as TypeId>::type_id().to_owned();
-        stream.push_str(&String::from(":"));
-        stream.push_str(&id.to_string());
-
-        let sequence = self.load_aggregate_sequence::<A>(id).await?;
-        let mut event_ids = Vec::with_capacity(events.len());
-
-        let sequence = sequence.unwrap_or(0);
-        let revision = u64::try_from(sequence).unwrap();
-        let options =
-            AppendToStreamOptions::default().expected_revision(ExpectedRevision::Exact(revision));
-
+        let revision = self.load_aggregate_sequence::<A>(id).await?.unwrap_or(0);
         let mut payload: Vec<EventData> = vec![];
 
-        for (index, event) in events.iter().enumerate() {
-            let created_at = Utc::now();
-            let aggregate_type = <A as TypeId>::type_id().to_string();
-            let aggregate_id = id.to_string();
-            let sequence = sequence.clone() + index;
-            let id = sequence.clone();
-            let data = serde_json::to_value(event).map_err(Error::SerializeEvent)?;
-            event_ids.push(id.clone());
-
+        for event in events.iter() {
             let event_data_payload = ESDBEventPayload {
-                created_at,
-                aggregate_type,
-                aggregate_id,
-                event_data: data,
+                created_at: Utc::now(),
+                aggregate_type: <A as TypeId>::type_id().to_string(),
+                aggregate_id: id.to_string(),
+                event_data: serde_json::to_value(event).map_err(Error::SerializeEvent)?,
             };
 
             let event_data = EventData::json(event.event_type(), &event_data_payload)
@@ -211,12 +195,14 @@ impl EventStore for ESDBEventStore {
             payload.push(event_data);
         }
 
+        let options =
+            AppendToStreamOptions::default().expected_revision(ExpectedRevision::Exact(revision as u64));
         let _ = self
             .client
-            .append_to_stream(&stream, &options, payload)
-            .map_err(|err| Error::WriteStreamError(sequence, err))
+            .append_to_stream(&self.stream_id::<A>(Some(id)), &options, payload)
+            .map_err(|err| Error::WriteStreamError(revision as usize, err))
             .await?;
 
-        Ok(event_ids)
+        Ok((revision..events.len() - 1).collect())
     }
 }

--- a/thalo-eventstoredb/src/lib.rs
+++ b/thalo-eventstoredb/src/lib.rs
@@ -1,4 +1,4 @@
-pub use event_store::ESDBEventStore;
+pub use event_store::{ESDBEventStore, ESDBEventPayload};
 pub use error::Error;
 
 mod error;

--- a/thalo-eventstoredb/src/lib.rs
+++ b/thalo-eventstoredb/src/lib.rs
@@ -4,11 +4,3 @@ pub use error::Error;
 mod error;
 mod event_store;
 
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        let result = 2 + 2;
-        assert_eq!(result, 4);
-    }
-}

--- a/thalo-eventstoredb/src/lib.rs
+++ b/thalo-eventstoredb/src/lib.rs
@@ -1,4 +1,5 @@
-#![deny(missing_docs)]
+pub use event_store::EventStoreDBEventStore;
+mod event_store;
 
 #[cfg(test)]
 mod tests {
@@ -8,6 +9,3 @@ mod tests {
         assert_eq!(result, 4);
     }
 }
-
-pub use event_store;
-mod event_store;

--- a/thalo-eventstoredb/src/lib.rs
+++ b/thalo-eventstoredb/src/lib.rs
@@ -1,4 +1,4 @@
-pub use event_store::EventStoreDBEventStore;
+pub use event_store::ESDBEventStore;
 pub use error::Error;
 
 mod error;

--- a/thalo-eventstoredb/src/lib.rs
+++ b/thalo-eventstoredb/src/lib.rs
@@ -1,0 +1,13 @@
+#![deny(missing_docs)]
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        let result = 2 + 2;
+        assert_eq!(result, 4);
+    }
+}
+
+pub use event_store;
+mod event_store;

--- a/thalo-eventstoredb/src/lib.rs
+++ b/thalo-eventstoredb/src/lib.rs
@@ -1,6 +1,5 @@
-pub use event_store::{ESDBEventStore, ESDBEventPayload};
 pub use error::Error;
+pub use event_store::{ESDBEventStore, EventPayload};
 
 mod error;
 mod event_store;
-

--- a/thalo-eventstoredb/src/lib.rs
+++ b/thalo-eventstoredb/src/lib.rs
@@ -1,4 +1,7 @@
 pub use event_store::EventStoreDBEventStore;
+pub use error::Error;
+
+mod error;
 mod event_store;
 
 #[cfg(test)]


### PR DESCRIPTION
Initial PR for event-store-db support in thalo. I won't make it an official PR until I get a chance to test drive this in my test app repository https://github.com/Shearerbeard/event-sourcing-pizza-delivery-demo-rs.

- [x] It would be nice if we could have event ids support usize as well as Uuid. ESDB prefers and supports Uuid by default rather than just storing the sequence as a key - with some more advanced features in ESDB this could be a problem eventually @tqwewe I may differ to your guidance here
- [x] EventStore.load_events_by_id is going to be really inefficient in ESDB and maybe isn't needed for any general use case other than manual debugging - in that case it might be easier to just use database tooling to inspect events
- [x] I'll be getting some confirmation from the ESDB team to make sure that the 2.0.0-alpha is the best current rust driver to be using - the 1.0.0 release is getting old and isn't as fleshed out
- [x] Example usage in README.md
- [x] Integrate into https://github.com/Shearerbeard/event-sourcing-pizza-delivery-demo-rs to test functionality and chase potential bugs
- [x] possibly plug into a fork of the /examples app and make sure it works there too